### PR TITLE
Added the option to separate fetch and push urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ $ missdev --https
 will use the `https` entry (if it exists) instead of the `url` entry for each repository
 
 ```
+$ missdev --fetch-https
+```
+will use the `https` entry (if it exists) instead of the `url` entry for each repository, ONLY for the fetch remote
+
+```
 $ missdev --default-to-master
 ```
 will checkout the master branch if the requested branch or tag does no exist in the repository.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mrs-developer",
-  "version": "1.1.5",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/command.js
+++ b/src/command.js
@@ -10,9 +10,10 @@ const configFileArg = args.find(function(arg) {return arg.startsWith('--config')
 const configFile = configFileArg && configFileArg.split('=')[1];
 const noConfig = args.indexOf('--no-config') > -1;
 const https = args.indexOf('--https') > -1;
+const fetchHttps = args.indexOf('--fetch-https') > -1;
 const defaultToMaster = args.indexOf('--default-to-master') > -1;
 const allMaster = args.indexOf('--all-master') > -1;
 const outputArg = args.find(function(arg) {return arg.startsWith('--output')});
 const output = outputArg && outputArg.split('=')[1];
 
-develop({noFetch, configFile, noConfig, output, reset, lastTag, https, defaultToMaster, allMaster});
+develop({noFetch, configFile, noConfig, output, reset, lastTag, https, fetchHttps, defaultToMaster, allMaster});

--- a/test/checkoutRepositoryTest.js
+++ b/test/checkoutRepositoryTest.js
@@ -24,6 +24,19 @@ describe('checkoutRepository', () => {
         const commits = await repo.log();
 		expect(commits.latest.message).to.be.equal('Modify file 1');
     });
+
+    it('sets separate fetch and push urls correctly', async () => {
+        await developer.checkoutRepository('repo1', './test/src/develop', {
+            url: './test/fake-push-remote/repo1',
+            https: './test/fake-remote/repo1',
+        }, {
+            fetchHttps: true,
+        });
+        const repo = await developer.openRepository('repo1', './test/src/develop/repo1');
+        const remotes = await repo.getRemotes(true);
+        expect(remotes[0].refs.fetch).to.contain('./test/fake-remote/repo1');
+        expect(remotes[0].refs.push).to.contain('./test/fake-push-remote/repo1');
+    });
     
     it('fetchs last changes if repository exists', async () => {
 		await developer.cloneRepository('repo1', './test/src/develop/repo1', './test/fake-remote/repo1');

--- a/test/cloneRepositoryTest.js
+++ b/test/cloneRepositoryTest.js
@@ -27,6 +27,18 @@ describe('cloneRepository', () => {
 		expect(remotes[0].name).to.be.equal('origin');
 	});
 
+    it('sets separate fetch and push urls correctly', async () => {
+        const repo = await developer.cloneRepository(
+			'repo1',
+			'./test/src/develop/repo1',
+            './test/fake-push-remote/repo1',
+            './test/fake-remote/repo1'
+        );
+        const remotes = await repo.getRemotes(true);
+        expect(remotes[0].refs.fetch).to.contain('./test/fake-remote/repo1');
+        expect(remotes[0].refs.push).to.contain('./test/fake-push-remote/repo1');
+    });
+
 	afterEach(async () => {
         await exec('./test/test-clean.sh');
 	});


### PR DESCRIPTION
Fixes #11 

Apparently, we can use the non-documented ``git.remote`` method to have full handling capabilities over the remotes without upgrading ``simple-git``.

I tried upgrading actually, as mentioned in the linked issue, but kept bumping into testing issues I couldn't solve. I could probably post the upgrade PR as well, in order to possibly save some hours to anyone who wants to work on that in the future, I'll see what I can do.