### PR TITLE
Disabled packages aware

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "singleQuote": true,
   "useTabs": false,
   "tabWidth": 2,
-  "bracketSpacing": true
+  "bracketSpacing": true,
+  "trailingComma": "all"
 }

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Properties:
 - `url`: Mandatory. Git repository remote URL.
 - `branch`: Optional. Branch name, defaults to the remote's default branch. Ignored if `tag` is defined.
 - `tag`: Optional. Tag name.
-- `develop`: Optional. Boolean, can be toggled on/off to activate/deactivate a package. If activated, then deactivated afterwards, the package gets removed from `jsconfig` maintaining the syncronization with `mrs.developer.json`. Default is true.
+- `develop`: Optional. Boolean, can be toggled on/off to activate/deactivate a package. If activated, then deactivated afterwards, the package gets removed from `jsconfig` maintaining the synchronization with `mrs.developer.json`. Default is `true`.
 
 ## Usage with (non-TypeScript) React
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ Properties:
 - `url`: Mandatory. Git repository remote URL.
 - `branch`: Optional. Branch name, defaults to the remote's default branch. Ignored if `tag` is defined.
 - `tag`: Optional. Tag name.
-- `develop`: Optional. Boolean, can be toggled on/off to activate/deactivate a package. Default is true.
+- `develop`: Optional. Boolean, can be toggled on/off to activate/deactivate a package. If activated, then deactivated afterwards, the package gets removed from `jsconfig` maintaining the syncronization with `mrs.developer.json`. Default is true.
 
-## Usage with React
+## Usage with (non-TypeScript) React
 
 Create a minimal `jsconfig.json` file in the project root (see https://code.visualstudio.com/docs/languages/jsconfig):
 

--- a/src/index.js
+++ b/src/index.js
@@ -315,6 +315,19 @@ async function develop(options) {
   }
 }
 
+function disabledPackages(options) {
+  const mrsDeveloperJSON = JSON.parse(
+    fs.readFileSync(path.join(options.root || '.', 'mrs.developer.json')),
+  );
+
+  return Object.entries(mrsDeveloperJSON || {})
+    .filter(([name, config]) => config.develop === false)
+    .reduce((acc, [name, config]) => {
+      acc.push(config.package || name);
+      return acc;
+    }, []);
+}
+
 function writeConfigFile(paths, options, developedPackages) {
   // update paths in configFile
   const defaultConfigFile = fs.existsSync('./tsconfig.base.json')
@@ -336,6 +349,7 @@ function writeConfigFile(paths, options, developedPackages) {
             : `src/${DEVELOP_DIRECTORY}`,
         ),
     )
+    .filter(([pkg, path]) => !disabledPackages(options).includes(pkg))
     .reduce((acc, [pkg, path]) => {
       acc[pkg] = path;
       return acc;


### PR DESCRIPTION
During development is usual to switch on/off development packages (using `develop` property). However, it used to be a PITA since you had to explicitly manually remove the package from `jsconfig`/`tsconfig` and it was proven to be quite error prone (especially in CI). 

I added a filter before writing the file that goes through all the config and checks if a explicitly disabled package is still present in the config and removes it if so.

Could be that I cannot see some of the implications or use cases, so please think about if it works for all your workflows.