### PR TITLE
Support for override output directory per repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ It is possible to keep a package in mrs-developer.json, but don't process it, by
 }
 ```
 
+You can override the default `output` provided via command line per repository in `mrs.developer.json`.
+
+```json
+{
+	"volto-light-theme": {
+		"output": "addons",
+		"package": "@kitconcept/volto-light-theme",
+		"url": "git@github.com:kitconcept/volto-light-theme.git",
+		"https": "https://github.com/kitconcept/volto-light-theme.git"
+	}
+}
+```
+
+This repository will be checked out in the `addons` directory, instead of the one provided via command line. It won't prepend the `src` prefix to it, if you still want it, you should provide it in the `output` key. This might be useful in combination with monorepos where you want to checkout packages into workspaces folders.
+
 ## Usage
 
 ```
@@ -154,7 +169,7 @@ Properties:
 - `branch`: Optional. Branch name, defaults to the remote's default branch. Ignored if `tag` is defined.
 - `tag`: Optional. Tag name.
 - `develop`: Optional. Boolean, can be toggled on/off to activate/deactivate a package. If activated, then deactivated afterwards, the package gets removed from `jsconfig` maintaining the synchronization with `mrs.developer.json`. Default is `true`.
-- `output`: Optional. Output directory override per repository. It also removes the `src/` prefix. If you still want it, you have to pass it along with the new output.
+- `output`: Optional. Output directory override per repository.
 
 ## Usage with (non-TypeScript) React
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Properties:
 - `branch`: Optional. Branch name, defaults to the remote's default branch. Ignored if `tag` is defined.
 - `tag`: Optional. Tag name.
 - `develop`: Optional. Boolean, can be toggled on/off to activate/deactivate a package. If activated, then deactivated afterwards, the package gets removed from `jsconfig` maintaining the synchronization with `mrs.developer.json`. Default is `true`.
+- `output`: Optional. Output directory override per repository. It also removes the `src/` prefix. If you still want it, you have to pass it along with the new output.
 
 ## Usage with (non-TypeScript) React
 

--- a/test/developTest.js
+++ b/test/developTest.js
@@ -23,6 +23,12 @@ describe('develop', () => {
     const repo3 = await developer.openRepository('repo3', './test/src/develop/repo3');
     commits = await repo3.log();
     expect(commits.latest.message).to.be.equal('Add file 2');
+    const repo5 = await developer.openRepository(
+      'repo5',
+      './test/packages/repo5',
+    );
+    commits = await repo5.log();
+    expect(commits.latest.message).to.be.equal('Add file 2');
   });
 
   it('updates tsconfig.json with proper paths', async () => {

--- a/test/getRepoDirTest.js
+++ b/test/getRepoDirTest.js
@@ -8,8 +8,13 @@ const exec = require('child_process').execSync;
 
 describe('getRepoDir', () => {
   it('creates the ./src/develop folder if it does not exist', () => {
-    developer.getRepoDir('./test');
+    developer.getRepoDir({ root: './test' });
     expect(fs.existsSync('./test/src/develop')).to.be.true;
+  });
+
+  it('creates a folder with no src if it does not exist', () => {
+    developer.getRepoDir({ root: './test' }, { output: 'packages' });
+    expect(fs.existsSync('./test/packages')).to.be.true;
   });
 
   afterEach(async () => {

--- a/test/mrs.developer.json
+++ b/test/mrs.developer.json
@@ -23,5 +23,9 @@
   },
   "local1": {
     "local": "some/path"
+  },
+  "repo5": {
+    "output": "packages",
+    "url": "./test/fake-remote/repo1"
   }
 }

--- a/test/test-clean.sh
+++ b/test/test-clean.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-rm -rf test/src/develop test/fake-remote
+rm -rf test/src/develop test/fake-remote test/packages

--- a/test/tsconfig-1.json
+++ b/test/tsconfig-1.json
@@ -25,6 +25,9 @@
             ],
             "local1": [
                 "src/some/path"
+            ],
+            "repo5": [
+                "src/develop/repo5"
             ]
         },
         "baseUrl": "./"

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -22,6 +22,9 @@
             ],
             "local1": [
                 "some/path"
+            ],
+            "repo5": [
+                "develop/repo5"
             ]
         },
         "baseUrl": "src"


### PR DESCRIPTION
I'd like to use `mrs-developer` to "populate" Volto core monorepo packages folders. 

So you can do:
```missdev --no-config --fetch-https```

```json
{
	"volto-light-theme": {
		"output": "addons",
		"package": "@kitconcept/volto-light-theme",
		"url": "git@github.com:kitconcept/volto-light-theme.git",
		"https": "https://github.com/kitconcept/volto-light-theme.git"
	}
}
```

And also open the door to have projects as monorepos:

```json
{
	"core": {
		"output": "./",
		"package": "@plone/volto",
		"url": "git@github.com:plone/volto.git",
		"https": "https://github.com/plone/volto.git"
	},
	"volto-light-theme": {
		"output": "addons",
		"package": "@kitconcept/volto-light-theme",
		"url": "git@github.com:kitconcept/volto-light-theme.git",
		"https": "https://github.com/kitconcept/volto-light-theme.git"
	}
}
```

Although then we need to alter internal Volto dependencies too, might be `mrs-developer` the one to do it, or an script, we'll see.