### PR TITLE
Do a partial clone without blobs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ function getDefaultBranch(repository) {
 function cloneRepository(name, path, url, fetchUrl) {
   console.log(`Cloning ${name} from ${fetchUrl || url}...`);
   return gitP()
-    .clone(getRemotePath(fetchUrl || url), path)
+    .clone(getRemotePath(fetchUrl || url), path, ["--filter=blob:none"])
     .then(() => {
       if (fetchUrl) {
         return gitP(path).remote([


### PR DESCRIPTION
@sneridagh I'm not sure how to test this, but it should make a clone fetch less data until it is actually checked out. See https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/ for more info.